### PR TITLE
Set the report button to be the positive one

### DIFF
--- a/firefox-mobile/bootstrap.js
+++ b/firefox-mobile/bootstrap.js
@@ -30,6 +30,7 @@ let desktopModeListener = {
   showMessage: function() {
     let buttons = [{
         label: "Yes",
+        positive: true,
         callback: () => reportIssue(this.win)
       }, {
         label: "No thanks",


### PR DESCRIPTION
Fixes #22. The doorhanger will only show two buttons if at least one of them has `positive: true` set. According to [the documentation](https://developer.mozilla.org/en-US/Add-ons/Firefox_for_Android/API/NativeWindow/doorhanger#Parameters_2), this is a requirement as of Fennec 41:

> [Firefox 41] Doorhangers will handle at most one `positive:true` button and one (implicitly) positive:false one, for a maximum of two buttons. Any additional buttons will not be displayed.

As a bonus, the "yes" button is now fancy and blue:

![screenshot_20160719-123843](https://cloud.githubusercontent.com/assets/344777/16947924/23802374-4db2-11e6-8380-688d308e6fc0.png)