### PR TITLE
Fixes #39. Send custom HTTP header when reporting issue.

### DIFF
--- a/chrome/background.js
+++ b/chrome/background.js
@@ -25,5 +25,5 @@ function reportIssue (tab) {
   });
 }
 
-chrome.contextMenus.onClicked.addListener(function (tab) { reportIssue(tab) });
-chrome.browserAction.onClicked.addListener(function (tab) { reportIssue(tab) });
+chrome.contextMenus.onClicked.addListener(reportIssue);
+chrome.browserAction.onClicked.addListener(reportIssue);

--- a/firefox-webext/background.js
+++ b/firefox-webext/background.js
@@ -4,6 +4,7 @@
 
 var prefix = 'https://webcompat.com/?open=1&url=';
 var screenshotData = '';
+var reporterID = 'addon-reporter-firefox';
 
 chrome.contextMenus.create({
   id: "webcompat-contextmenu",
@@ -26,3 +27,17 @@ function reportIssue (tab) {
 
 chrome.contextMenus.onClicked.addListener(reportIssue);
 chrome.browserAction.onClicked.addListener(reportIssue);
+
+// Add a custom header when the user is reporting an issue.
+chrome.webRequest.onBeforeSendHeaders.addListener(
+  function(details) {
+    details.requestHeaders.push({
+      name: 'X-Reported-With',
+      value: `${reporterID}`
+    });
+
+    return {requestHeaders: details.requestHeaders};
+  },
+  {urls: ["https://webcompat.com/?open=1&*"]},
+  ['blocking', 'requestHeaders']
+);

--- a/firefox-webext/background.js
+++ b/firefox-webext/background.js
@@ -11,7 +11,6 @@ chrome.contextMenus.create({
   contexts: ["all"]
 });
 
-
 function reportIssue (tab) {
   chrome.tabs.captureVisibleTab({format: 'png'}, function(res) {
     screenshotData = res;
@@ -25,5 +24,5 @@ function reportIssue (tab) {
   });
 }
 
-chrome.contextMenus.onClicked.addListener(function (tab) { reportIssue(tab) });
-chrome.browserAction.onClicked.addListener(function (tab) { reportIssue(tab) });
+chrome.contextMenus.onClicked.addListener(reportIssue);
+chrome.browserAction.onClicked.addListener(reportIssue);

--- a/firefox-webext/manifest.json
+++ b/firefox-webext/manifest.json
@@ -23,6 +23,8 @@
     "tabs",
     "activeTab",
     "contextMenus",
+    "webRequest",
+    "webRequestBlocking",
     "https://webcompat.com/",
     "<all_urls>"
   ],

--- a/opera/background.js
+++ b/opera/background.js
@@ -25,5 +25,5 @@ function reportIssue (tab) {
   });
 }
 
-chrome.contextMenus.onClicked.addListener(function (tab) { reportIssue(tab) });
-chrome.browserAction.onClicked.addListener(function (tab) { reportIssue(tab) });
+chrome.contextMenus.onClicked.addListener(reportIssue);
+chrome.browserAction.onClicked.addListener(reportIssue);


### PR DESCRIPTION
Not added to Chrome or Opera yet, will do in a follow up commit before merging once it gets an r+.

@karlcow, r?