### PR TITLE
Fixes #61. Use http/https allowlist for isReportableURL

### DIFF
--- a/chrome/background.js
+++ b/chrome/background.js
@@ -30,11 +30,12 @@ function reportIssue(tab) {
 
 function enableOrDisable(tabId, changeInfo, tab) {
   function isReportableURL(url) {
-    return url && !(url.startsWith("about")     ||
-                    url.startsWith("chrome")    ||
-                    url.startsWith("file")      ||
-                    url.startsWith("resource")  ||
-                    url.startsWith("view-source"));
+    if (!url) {
+      return false;
+    }
+
+    let protocol = new URL(url).protocol;
+    return ["http:", "https:"].includes(protocol);
   }
 
   if (changeInfo.status == "complete" && isReportableURL(tab.url)) {

--- a/chrome/background.js
+++ b/chrome/background.js
@@ -2,24 +2,24 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-var prefix = 'https://webcompat.com/issues/new?url=';
-var screenshotData = '';
-var reporterID = 'addon-reporter-chrome';
+var prefix = "https://webcompat.com/issues/new?url=";
+var screenshotData = "";
+var reporterID = "addon-reporter-chrome";
 
 chrome.contextMenus.create({
-  id: 'webcompat-contextmenu',
-  title: 'Report site issue',
-  contexts: ['all']
+  id: "webcompat-contextmenu",
+  title: "Report site issue",
+  contexts: ["all"]
 });
 
 
 function reportIssue(tab) {
-  chrome.tabs.captureVisibleTab({format: 'png'}, function(res) {
+  chrome.tabs.captureVisibleTab({format: "png"}, function(res) {
     screenshotData = res;
     chrome.tabs.query({currentWindow: true, active: true}, function(tab) {
       var newTabUrl =
         `${prefix}${encodeURIComponent(tab[0].url)}&src=${reporterID}`;
-      chrome.tabs.create({ 'url': newTabUrl}, function(tab) {
+      chrome.tabs.create({ "url": newTabUrl}, function(tab) {
         chrome.tabs.executeScript({
           code: `window.postMessage("${screenshotData}", "*")`
         });
@@ -38,9 +38,9 @@ function enableOrDisable(tabId, changeInfo, tab) {
     return ["http:", "https:"].includes(protocol);
   }
 
-  if (changeInfo.status == "complete" && isReportableURL(tab.url)) {
+  if (changeInfo.status === "complete" && isReportableURL(tab.url)) {
     chrome.browserAction.enable(tabId);
-  } else if (changeInfo.status == "complete" && !isReportableURL(tab.url)) {
+  } else if (changeInfo.status === "complete" && !isReportableURL(tab.url)) {
     chrome.browserAction.disable(tabId);
   }
 }

--- a/firefox/background.js
+++ b/firefox/background.js
@@ -29,11 +29,12 @@ function reportIssue(tab) {
 
 function enableOrDisable(tabId, changeInfo, tab) {
   function isReportableURL(url) {
-    return url && !(url.startsWith("about")     ||
-                    url.startsWith("chrome")    ||
-                    url.startsWith("file")      ||
-                    url.startsWith("resource")  ||
-                    url.startsWith("view-source"));
+    if (!url) {
+      return false;
+    }
+
+    let protocol = new URL(url).protocol;
+    return ["http:", "https:"].includes(protocol);
   }
 
   if (changeInfo.status == "loading" && isReportableURL(tab.url)) {

--- a/firefox/background.js
+++ b/firefox/background.js
@@ -2,23 +2,23 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-var prefix = 'https://webcompat.com/issues/new?url=';
-var screenshotData = '';
-var reporterID = 'addon-reporter-firefox';
+var prefix = "https://webcompat.com/issues/new?url=";
+var screenshotData = "";
+var reporterID = "addon-reporter-firefox";
 
 chrome.contextMenus.create({
-  id: 'webcompat-contextmenu',
-  title: 'Report site issue',
-  contexts: ['all']
+  id: "webcompat-contextmenu",
+  title: "Report site issue",
+  contexts: ["all"]
 });
 
 function reportIssue(tab) {
-  chrome.tabs.captureVisibleTab({format: 'png'}, function(res) {
+  chrome.tabs.captureVisibleTab({format: "png"}, function(res) {
     screenshotData = res;
     chrome.tabs.query({currentWindow: true, active: true}, function(tab) {
       var newTabUrl =
         `${prefix}${encodeURIComponent(tab[0].url)}&src=${reporterID}`;
-      chrome.tabs.create({ 'url': newTabUrl}, function(tab) {
+      chrome.tabs.create({ "url": newTabUrl}, function(tab) {
         chrome.tabs.executeScript({
           code: `window.postMessage("${screenshotData}", "*")`
         });
@@ -37,9 +37,9 @@ function enableOrDisable(tabId, changeInfo, tab) {
     return ["http:", "https:"].includes(protocol);
   }
 
-  if (changeInfo.status == "loading" && isReportableURL(tab.url)) {
+  if (changeInfo.status === "loading" && isReportableURL(tab.url)) {
     chrome.browserAction.enable(tabId);
-  } else if (changeInfo.status == "loading" && !isReportableURL(tab.url)) {
+  } else if (changeInfo.status === "loading" && !isReportableURL(tab.url)) {
     chrome.browserAction.disable(tabId);
   }
 }
@@ -48,7 +48,7 @@ chrome.tabs.onCreated.addListener((tab) => {
   // disable all new tabs until they've loaded and we know
   // they have reportable URLs
   chrome.browserAction.disable(tab.tabId);
-})
+});
 chrome.tabs.onUpdated.addListener(enableOrDisable);
 chrome.contextMenus.onClicked.addListener(reportIssue);
 chrome.browserAction.onClicked.addListener(reportIssue);

--- a/opera/background.js
+++ b/opera/background.js
@@ -30,11 +30,12 @@ function reportIssue(tab) {
 
 function enableOrDisable(tabId, changeInfo, tab) {
   function isReportableURL(url) {
-    return url && !(url.startsWith("about")     ||
-                    url.startsWith("chrome")    ||
-                    url.startsWith("file")      ||
-                    url.startsWith("resource")  ||
-                    url.startsWith("view-source"));
+    if (!url) {
+      return false;
+    }
+
+    let protocol = new URL(url).protocol;
+    return ["http:", "https:"].includes(protocol);
   }
 
   if (changeInfo.status == "loading" && isReportableURL(tab.url)) {

--- a/opera/background.js
+++ b/opera/background.js
@@ -2,24 +2,24 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-var prefix = 'https://webcompat.com/issues/new?url=';
-var screenshotData = '';
-var reporterID = 'addon-reporter-opera';
+var prefix = "https://webcompat.com/issues/new?url=";
+var screenshotData = "";
+var reporterID = "addon-reporter-opera";
 
 chrome.contextMenus.create({
-  id: 'webcompat-contextmenu',
-  title: 'Report site issue',
-  contexts: ['all']
+  id: "webcompat-contextmenu",
+  title: "Report site issue",
+  contexts: ["all"]
 });
 
 
 function reportIssue(tab) {
-  chrome.tabs.captureVisibleTab({format: 'png'}, function(res) {
+  chrome.tabs.captureVisibleTab({format: "png"}, function(res) {
     screenshotData = res;
     chrome.tabs.query({currentWindow: true, active: true}, function(tab) {
       var newTabUrl =
         `${prefix}${encodeURIComponent(tab[0].url)}&src=${reporterID}`;
-      chrome.tabs.create({ 'url': prefix + encodeURIComponent(tab[0].url)}, function(tab) {
+      chrome.tabs.create({ "url": newTabUrl}, function(tab) {
         chrome.tabs.executeScript({
           code: `window.postMessage("${screenshotData}", "*")`
         });
@@ -38,9 +38,9 @@ function enableOrDisable(tabId, changeInfo, tab) {
     return ["http:", "https:"].includes(protocol);
   }
 
-  if (changeInfo.status == "loading" && isReportableURL(tab.url)) {
+  if (changeInfo.status === "loading" && isReportableURL(tab.url)) {
     chrome.browserAction.enable(tabId);
-  } else if (changeInfo.status == "loading" && !isReportableURL(tab.url)) {
+  } else if (changeInfo.status === "loading" && !isReportableURL(tab.url)) {
     chrome.browserAction.disable(tabId);
   }
 }


### PR DESCRIPTION
(ignoring the fact that these 3 files should be a single file included at build-time for the 3 browsers...)

Also some eslint fixups.

r? @wisniewskit 