### PR TITLE
Fixes #78: Derive addon version from package.json version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Links to extension sites coming soon.
 Another way to easily report issues is via a [bookmarklet](http://en.wikipedia.org/wiki/Bookmarklet). Make one of those however you make them normally, and copy and paste the following code:
 
 ```
-javascript:(function(){location.href="http://webcompat.com/?open=1&url="+encodeURIComponent(location.href)}())
+javascript:(function(){location.href="https://webcompat.com/?open=1&url="+encodeURIComponent(location.href)}())
 ```
 
 ### Building

--- a/chrome/webpack.config.js
+++ b/chrome/webpack.config.js
@@ -5,6 +5,7 @@
 // webpack config to bundle the Chrome web extension from shared sources.
 
 const CopyWebpackPlugin = require("copy-webpack-plugin");
+const version = require("../package.json").version;
 
 module.exports = {
   entry: "./chrome/addon.js",
@@ -23,7 +24,13 @@ module.exports = {
       },
       {
         from: "shared/manifest.json",
-        to: "./dist/chrome/[name].json"
+        to: "./dist/chrome/[name].json",
+        transform: function(content, path) {
+          let manifest = JSON.parse(content);
+          // Derive addon versioning from package.json
+          manifest["version"] = version;
+          return JSON.stringify(manifest, null, 2);
+        }
       }
     ])
   ]

--- a/firefox-mobile/manifest.json
+++ b/firefox-mobile/manifest.json
@@ -2,7 +2,6 @@
   "manifest_version": 2,
   "name": "webcompat.com reporter",
   "description": "Report website compatibility issues at webcompat.com",
-  "version": "0.5.0",
   "background": {
     "scripts": ["background.js"]
   },

--- a/firefox-mobile/webpack.config.js
+++ b/firefox-mobile/webpack.config.js
@@ -5,6 +5,7 @@
 // webpack config to bundle the Firefox for Android web extension from shared sources.
 
 const CopyWebpackPlugin = require("copy-webpack-plugin");
+const version = require("../package.json").version;
 
 module.exports = {
   entry: "./firefox-mobile/addon.js",
@@ -27,6 +28,8 @@ module.exports = {
         transform: function(content, path) {
           // Add Firefox-specific bits to the manifest.json
           let manifest = JSON.parse(content);
+          // Derive addon versioning from package.json
+          manifest["version"] = version;
           manifest["applications"] = {
             gecko: {
               id: "webcompat-reporter-for-mobile@webcompat.com",

--- a/firefox/webpack.config.js
+++ b/firefox/webpack.config.js
@@ -5,6 +5,7 @@
 // webpack config to bundle the Firefox web extension from shared sources.
 
 const CopyWebpackPlugin = require("copy-webpack-plugin");
+const version = require("../package.json").version;
 
 module.exports = {
   entry: "./firefox/addon.js",
@@ -25,8 +26,10 @@ module.exports = {
         from: "shared/manifest.json",
         to: "./dist/firefox/[name].json",
         transform: function(content, path) {
-          // Add Firefox-specific bits to the manifest.json
           let manifest = JSON.parse(content);
+          // Derive addon versioning from package.json
+          manifest["version"] = version;
+          // Add Firefox-specific bits to the manifest.json
           manifest["applications"] = {
             gecko: {
               id: "jid1-mjpB54bRzP9Zxw@jetpack",

--- a/opera/webpack.config.js
+++ b/opera/webpack.config.js
@@ -5,6 +5,7 @@
 // webpack config to bundle the Opera web extension from shared sources.
 
 const CopyWebpackPlugin = require("copy-webpack-plugin");
+const version = require("../package.json").version;
 
 module.exports = {
   entry: "./opera/addon.js",
@@ -23,7 +24,13 @@ module.exports = {
       },
       {
         from: "shared/manifest.json",
-        to: "./dist/opera/[name].json"
+        to: "./dist/opera/[name].json",
+        transform: function(content, path) {
+          let manifest = JSON.parse(content);
+          // Derive addon versioning from package.json
+          manifest["version"] = version;
+          return JSON.stringify(manifest, null, 2);
+        }
       }
     ])
   ]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webcompat-reporter-addon",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "WebCompat reporter add-ons.",
   "author": "webcompat.com contributors",
   "scripts": {

--- a/shared/manifest.json
+++ b/shared/manifest.json
@@ -2,7 +2,6 @@
   "manifest_version": 2,
   "name": "webcompat.com reporter",
   "description": "Report website compatibility issues at webcompat.com",
-  "version": "0.5.0",
   "background": {
     "scripts": ["background.js"]
   },


### PR DESCRIPTION
As long as we keep desktop + mobile in sync in terms of feature parity, this should work out. I guess if things diverge, I'll just make the fennec addon be a manual thing.

r? @denschub 