### PR TITLE
Fixes #91. Add support for i18n.

### DIFF
--- a/chrome/webpack.config.js
+++ b/chrome/webpack.config.js
@@ -15,6 +15,14 @@ module.exports = {
   plugins: [
     new CopyWebpackPlugin([
       {
+        from: "shared/_locales/en/messages.json",
+        to: "../dist/chrome/_locales/en/messages.json"
+      },
+      {
+        from: "shared/_locales/it/messages.json",
+        to: "../dist/chrome/_locales/it/messages.json"
+      },
+      {
         from: "shared/content.js",
         to: "../dist/chrome/content.js"
       },

--- a/firefox-mobile/manifest.json
+++ b/firefox-mobile/manifest.json
@@ -26,5 +26,6 @@
   },
   "browser_action": {
     "default_title": "Report site issue"
-  }
+  },
+  "default_locale": "en"
 }

--- a/firefox-mobile/webpack.config.js
+++ b/firefox-mobile/webpack.config.js
@@ -15,6 +15,14 @@ module.exports = {
   plugins: [
     new CopyWebpackPlugin([
       {
+        from: "shared/_locales/en/messages.json",
+        to: "../dist/firefox-mobile/_locales/en/messages.json"
+      },
+      {
+        from: "shared/_locales/it/messages.json",
+        to: "../dist/firefox-mobile/_locales/it/messages.json"
+      },
+      {
         from: "shared/content.js",
         to: "../dist/firefox-mobile/content.js"
       },

--- a/firefox/webpack.config.js
+++ b/firefox/webpack.config.js
@@ -15,6 +15,14 @@ module.exports = {
   plugins: [
     new CopyWebpackPlugin([
       {
+        from: "shared/_locales/en/messages.json",
+        to: "../dist/firefox/_locales/en/messages.json"
+      },
+      {
+        from: "shared/_locales/it/messages.json",
+        to: "../dist/firefox/_locales/it/messages.json"
+      },
+      {
         from: "shared/content.js",
         to: "../dist/firefox/content.js"
       },

--- a/opera/webpack.config.js
+++ b/opera/webpack.config.js
@@ -15,6 +15,14 @@ module.exports = {
   plugins: [
     new CopyWebpackPlugin([
       {
+        from: "shared/_locales/en/messages.json",
+        to: "../dist/opera/_locales/en/messages.json"
+      },
+      {
+        from: "shared/_locales/it/messages.json",
+        to: "../dist/opera/_locales/it/messages.json"
+      },
+      {
         from: "shared/content.js",
         to: "../dist/opera/content.js"
       },

--- a/shared/_locales/en/messages.json
+++ b/shared/_locales/en/messages.json
@@ -1,0 +1,10 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+{
+ "contextMenuTitle": {
+    "message": "Report site issue",
+    "description": "Title for context menu item."
+  }
+}

--- a/shared/base.js
+++ b/shared/base.js
@@ -9,7 +9,7 @@ const PREFIX = "https://webcompat.com/issues/new?url=";
 function createContextMenu() {
   chrome.contextMenus.create({
     id: "webcompat-contextmenu",
-    title: "Report site issue",
+    title: chrome.i18n.getMessage("contextMenuTitle"),
     contexts: ["all"]
   });
 }

--- a/shared/manifest.json
+++ b/shared/manifest.json
@@ -34,5 +34,6 @@
       "128": "icon128.png"
     },
     "default_title": "Report Site Issue"
-  }
+  },
+  "default_locale": "en"
 }


### PR DESCRIPTION
This is super bare bones, but I managed to test a version with an Italian resource folder as a temporary add-on and can confirm it works to change the context menu text. I left the name & description parts alone for now as 

FYI: There was some testing hairiness in that [all target language packs must be installed (see "Testing out your extension section")](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Internationalization), which wasn't 100% clear from the documentation, but [this may be simplified in a future FF version.](https://bugzilla.mozilla.org/show_bug.cgi?id=1440969)

r? @miketaylr  