### PR TITLE
Fixes #129. Add missing locales dir to webpack config and test helper module.

### DIFF
--- a/tests/lib/helpers.js
+++ b/tests/lib/helpers.js
@@ -22,6 +22,10 @@ function compileWebpack() {
           plugins: [
             new CopyWebpackPlugin([
               {
+                from: "shared/_locales/",
+                to: `../dist/${platform}/_locales/`
+              },
+              {
                 from: "shared/content.js",
                 to: `../dist/${platform}/content.js`
               },

--- a/tests/test-dist-output.js
+++ b/tests/test-dist-output.js
@@ -14,8 +14,8 @@ registerSuite("dist output", {
     return helpers.compileWebpack();
   },
   tests: {
-    "has shared output"() {
-      // verify dist assets got added
+    "has shared output (single files)"() {
+      // verify single file dist assets got added
       ["chrome", "opera", "firefox-mobile", "firefox"].forEach(browser => {
         [
           "background.js",
@@ -27,7 +27,25 @@ registerSuite("dist output", {
           "manifest.json"
         ].forEach(file => {
           fileExists(`dist/${browser}/${file}`, (err, exists) =>
-            assert.isTrue(exists)
+            assert.isTrue(
+              exists,
+              "all shared single-file assets are included in dist output"
+            )
+          );
+        });
+      });
+    },
+    "has _locales directory with all l18n message files"() {
+      // verify localization directory dist asset was added
+      ["chrome", "opera", "firefox-mobile", "firefox"].forEach(browser => {
+        ["en"].forEach(lang => {
+          fileExists(
+            `dist/${browser}/_locales/${lang}/messages.json`,
+            (err, exists) =>
+              assert.isTrue(
+                exists,
+                "locales directory with all current translations is included in dist output"
+              )
           );
         });
       });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -17,6 +17,10 @@ module.exports = function(env) {
     plugins: [
       new CopyWebpackPlugin([
         {
+          from: "shared/_locales/",
+          to: `../dist/${env}/_locales/`
+        },
+        {
           from: "shared/content.js",
           to: `../dist/${env}/content.js`
         },


### PR DESCRIPTION
I have no idea how this got left out, but now it's in. I'm going to add another commit tomorrow to insert a check for the `_locales` directory contents into the dist-output test, too.