### PR TITLE
Fixes #131. Update classname to hide download link on webcompat.com.

### DIFF
--- a/shared/content.js
+++ b/shared/content.js
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
 // add a class to hide the download link when the add-on is installed.
-document.querySelector(".js-Navbar-link").classList.add("is-hidden");
+
+document.querySelector(".js-addon-link").classList.add("is-hidden");

--- a/shared/content.js
+++ b/shared/content.js
@@ -3,4 +3,4 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 // add a class to hide the download link when the add-on is installed.
 
-document.querySelector(".js-addon-link").classList.add("is-hidden");
+document.querySelector(".js-addon-link").style.display = "none";


### PR DESCRIPTION
I went ahead and switched out the old classname link for the current one. Unit tests pass, and when I test in the command line of the console `is-hidden` is definitely coming up as part of the class list. But I can't get any of the practical testing methods to work in any of my firefox versions (or chrome), so I'm not confident something bigger isn't broken.

I've never gotten the dev dependency `web-ext` to work (as other noted in #101 / #105). So the last time I tested, I just added the unsigned addon in about:debugging, which worked fine. Now that's either messed up, too, or there's something fishy with the extensions. 

There's definitely something amiss with `web-ext` + firefox (and/or in the way webpack bundles -- I keep getting "don't use `eval()`, it's evil" errors in ff console). I'd file a bug, but I can't narrow down the problem enough to know where to do so.

Installing `web-ext` globally or linking to source **does** start firefox with the addon, but there are some weird warnings/logging that pop up, and the addon keeps deactivating itself. Plus, w-e installs something like 900+ (npm global install) to 1300 packages (npm link from source), which, idk, seems ... like an awful lot? Maybe there's some kind of dependency conflict that's messing with function?

Anyway, here's this. If you have time and it works on your end, great, if not ... 🤷‍♀️ 😄 