### PR TITLE
Fixes #135 - Update webpack-cli to v3

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,3 @@
 {
-  "plugins": ["transform-es2015-modules-commonjs"]
+  "plugins": ["babel-plugin-transform-es2015-modules-commonjs"]
 }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "shx": "^0.2.2",
     "web-ext": "^2.4.0",
     "webpack": "^4.1.1",
-    "webpack-cli": "^2.0.10"
+    "webpack-cli": "^3.1.1"
   },
   "license": "MPL-2.0"
 }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "homepage": "https://github.com/webcompat/webcompat-reporter-extensions#readme",
   "devDependencies": {
+    "babel-plugin-transform-es2015-modules-commonjs": "^6.26.2",
     "chrome-launch": "^1.1.4",
     "copy-webpack-plugin": "^4.3.1",
     "crx": "^3.2.1",


### PR DESCRIPTION
Webpack v4.20 exposed a CLI issue (some call to read a property of a potentially undefined object), and [their official suggested fix was to update `webpack-cli` to v3.1.1](https://github.com/webpack/webpack/releases/tag/v4.20.0).